### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/process_train.py
+++ b/process_train.py
@@ -21,7 +21,7 @@ print('Finish Reading! len = ', len(train_set))
 
 
 from hotpot_evaluate_v1 import normalize_answer, f1_score
-from fuzzywuzzy import fuzz, process as fuzzy_process
+from rapidfuzz import fuzz, process as fuzzy_process
 
 def fuzzy_retrive(entity, pool):
     if len(pool) > 100:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 fire==0.1.3
-fuzzywuzzy==0.17.0
-python-Levenshtein==0.12.0
+rapidfuzz==0.2.0
 pytorch-pretrained-bert==0.6.2
 redis==3.2.1
 torch==1.0.1.post2

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,4 @@
-from fuzzywuzzy import fuzz, process as fuzzy_process
+from rapidfuzz import fuzz, process as fuzzy_process
 import re
 import numpy as np
 from bisect import bisect_left


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.